### PR TITLE
Add run_easyaccess script

### DIFF
--- a/scripts/run_easyaccess.sh
+++ b/scripts/run_easyaccess.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+cd ~/ea2
+export BOX86_LOG=1
+export WINEDEBUG=-all
+Xvfb :1 -screen 0 1024x768x16 &
+export DISPLAY=:1
+box86 wine eClient.exe


### PR DESCRIPTION
## Summary
- add a `run_easyaccess.sh` script to start easy access with Box86 and Wine

## Testing
- `bash -n scripts/run_easyaccess.sh`


------
https://chatgpt.com/codex/tasks/task_b_68489adfcb64832b909a4d4cc307e29b